### PR TITLE
Add Fast Debug Mode

### DIFF
--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -30,6 +30,16 @@ public:
    // code..
 
    mainWindow.reset(new MainWindow(getApplicationName()));
+
+   // JUCE doesn't seem to have a "everything is ready" methond as there are
+   // many threads and "is ready" is really arbitrary to what one is looking
+   // for. The goal of this delay is to be invoked when a normal user would be
+   // able to start giving input (a few milliseconds should be enough).
+   juce::Timer::callAfterDelay(250, [this]() {
+     juce::Component* mainComponent = mainWindow->getContentComponent();
+     jassert(mainComponent != nullptr);
+     reinterpret_cast<MainComponent*>(mainComponent)->fastDebugMode();
+   });
  }
 
  void shutdown() override {

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -209,17 +209,27 @@ void MainComponent::resized() {
       mArcSpec.getBounds().withSizeKeepingCentre(PROGRESS_SIZE, PROGRESS_SIZE));
 }
 
-void MainComponent::openNewFile() {
+/** Pauses audio to open file
+    @param path optional path to load, otherwise will prompt user for file
+   location
+*/
+void MainComponent::openNewFile(const char* path) {
   shutdownAudio();
 
-  juce::FileChooser chooser("Select a file to granulize...",
-                            juce::File::getCurrentWorkingDirectory(), "*.wav;*.mp3",
-                            true);
+  if (path == nullptr) {
+    juce::FileChooser chooser("Select a file to granulize...",
+                              juce::File::getCurrentWorkingDirectory(),
+                              "*.wav;*.mp3", true);
 
-  if (chooser.browseForFileToOpen()) {
-    auto file = chooser.getResult();
+    if (chooser.browseForFileToOpen()) {
+      auto file = chooser.getResult();
+      processFile(file);
+    }
+  } else {
+    auto file = juce::File(juce::String(path));
     processFile(file);
   }
+
   setAudioChannels(2, 2);
 }
 
@@ -288,4 +298,15 @@ void MainComponent::stopRecording() {
   mBtnRecord.setButtonText("Start Recording");
   mBtnRecord.setColour(juce::TextButton::ColourIds::buttonColourId,
                        juce::Colours::green);
+}
+
+/** Fast Debug Mode is used to speed up iterations of testing
+    This method should be called only once and no-op if not being used
+*/
+void MainComponent::fastDebugMode() {
+#ifdef FDB_LOAD_FILE
+  // Loads a file right away - make sure macro is in quotes in Projucer
+  DBG("Fast Debug Mode - Loading file " << FDB_LOAD_FILE);
+  openNewFile(FDB_LOAD_FILE);
+#endif  // FDB_LOAD_FILE
 }

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -43,6 +43,8 @@ class MainComponent : public juce::AudioAppComponent,
   //==============================================================================
   void timerCallback() override;
 
+  void fastDebugMode();
+
  private:
   /* Algorithm Constants */
   static constexpr auto FFT_SIZE = 4096;
@@ -93,7 +95,7 @@ class MainComponent : public juce::AudioAppComponent,
   juce::File mRecordedFile;
   juce::AudioDeviceManager mAudioDeviceManager;
 
-  void openNewFile();
+  void openNewFile(const char* path = nullptr);
   void processFile(juce::File file);
   void startRecording();
   void stopRecording();


### PR DESCRIPTION
> Note first commit is just running clang format before adding anything, just view the 2nd commit

The goal of this is to speed future iterations of debugging a UI

By just setting a define macro, which I can do in my `make` build command, but can also be easily set in [Visual Studio](https://docs.microsoft.com/en-us/cpp/build/working-with-project-properties?view=msvc-160#user-defined-macros) or Projucer even (will just need to not check it in then)
![fdm](https://user-images.githubusercontent.com/9061055/124092643-eff15c80-da0b-11eb-8a4e-647c8930e340.png)

for `FDM_LOAD_FILE` it will just open the file for me right away

This will be super nice when we want to reproduce various UI steps each time debugging something in future