### PR TITLE
linux: Add JUCE_MODAL_LOOPS_PERMITTED=1 workaround

### DIFF
--- a/gRainbow.jucer
+++ b/gRainbow.jucer
@@ -83,8 +83,8 @@
   <EXPORTFORMATS>
     <LINUX_MAKE targetFolder="Builds/LinuxMakefile">
       <CONFIGURATIONS>
-        <CONFIGURATION isDebug="1" name="Debug" targetName="gRainbow"/>
-        <CONFIGURATION isDebug="0" name="Release" targetName="gRainbow"/>
+        <CONFIGURATION isDebug="1" name="Debug" targetName="gRainbow" defines="JUCE_MODAL_LOOPS_PERMITTED=1"/>
+        <CONFIGURATION isDebug="0" name="Release" targetName="gRainbow" defines="JUCE_MODAL_LOOPS_PERMITTED=1"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_audio_basics" path="../../../../../../JUCE/modules"/>


### PR DESCRIPTION
When upgrading to JUCE 6.1.0+ there is a breaking change

https://github.com/juce-framework/JUCE/blob/6d6ecffb9dbdc2828b20a1c12373eed63696bdff/BREAKING-CHANGES.txt#L100

Might come across this as well for Windows/Mac

I got the error

```
../../Source/PluginEditor.cpp:280:17: error: no member named 'browseForFileToOpen' in 'juce::FileChooser'
    if (chooser.browseForFileToOpen()) {
        ~~~~~~~ ^
```