### PR TITLE
Fix candidate position bug

### DIFF
--- a/Source/GeneratorsBox.cpp
+++ b/Source/GeneratorsBox.cpp
@@ -339,7 +339,6 @@ void GeneratorsBox::paint(juce::Graphics& g) {
   float tabWidth = getWidth() / NUM_GENERATORS;
   float curStart = 1.0f;
   for (int i = 0; i < NUM_GENERATORS; ++i) {
-    ParamGenerator* gen = mParamsNote.notes[mCurPitchClass]->generators[i].get();
     juce::Colour tabColour = mParamsNote.notes[mCurPitchClass]->shouldPlayGenerator(i)
                                  ? juce::Colour(Utils::GENERATOR_COLOURS_HEX[i])
                                  : juce::Colours::darkgrey;

--- a/Source/GranularSynth.cpp
+++ b/Source/GranularSynth.cpp
@@ -414,13 +414,13 @@ void GranularSynth::processFile(juce::AudioBuffer<float>* audioBuffer, double sa
   }
 }
 
-int GranularSynth::incrementPosition(int boxNum, bool lookRight) {
+int GranularSynth::incrementPosition(int genIdx, bool lookRight) {
   int numCandidates = mParamsNote.notes[mLastPitchClass]->candidates.size();
-  int pos = mParamsNote.notes[mLastPitchClass]->generators[boxNum]->candidate->get();
+  int pos = mParamsNote.notes[mLastPitchClass]->generators[genIdx]->candidate->get();
   if (numCandidates == 0) return pos;
   int newPos = lookRight ? pos + 1 : pos - 1;
   newPos = (newPos + numCandidates) % numCandidates;
-  ParamHelper::setParam(mParamsNote.notes[mLastPitchClass]->generators[boxNum]->candidate, newPos);
+  ParamHelper::setParam(mParamsNote.notes[mLastPitchClass]->generators[genIdx]->candidate, newPos);
   return newPos;
 }
 
@@ -509,5 +509,7 @@ void GranularSynth::createCandidates(juce::HashMap<Utils::PitchClass, std::vecto
       numSearches++;
       if (numSearches >= 6 || foundAll) break;
     }
+
+    note->setStartingCandidatePosition();
   }
 }

--- a/Source/GranularSynth.h
+++ b/Source/GranularSynth.h
@@ -88,7 +88,7 @@ class GranularSynth : public juce::AudioProcessor, juce::MidiKeyboardState::List
 
   ParamUI& getParamUI() { return mParamUI; }
   void resetParameters();
-  int incrementPosition(int boxNum, bool lookRight);
+  int incrementPosition(int genIdx, bool lookRight);
   std::vector<ParamCandidate*> getActiveCandidates();
 
  private:
@@ -108,14 +108,13 @@ class GranularSynth : public juce::AudioProcessor, juce::MidiKeyboardState::List
     Utils::EnvelopeADSR ampEnv;
     std::array<Utils::EnvelopeADSR, NUM_GENERATORS> genAmpEnvs;
     juce::Array<Grain> grains;         // Active grains for note
-    std::vector<float> grainTriggers;  // Keeps track of triggering grains from
-                                       // each generator
+    std::array<float, NUM_GENERATORS> grainTriggers;  // Keeps track of triggering grains from each generator
     GrainNote(Utils::PitchClass pitchClass, float velocity, Utils::EnvelopeADSR ampEnv)
         : pitchClass(pitchClass), velocity(velocity), ampEnv(ampEnv) {
       grains.ensureStorageAllocated(MAX_GRAINS);
       // Initialize grain triggering timestamps
+      grainTriggers.fill(-1.0f);  // Trigger first set of grains right away
       for (int i = 0; i < NUM_GENERATORS; ++i) {
-        grainTriggers.push_back(-1);            // Trigger first set of grains right away
         genAmpEnvs[i].noteOn(ampEnv.noteOnTs);  // Set note on for each position as well
       }
     }

--- a/Source/Parameters.cpp
+++ b/Source/Parameters.cpp
@@ -39,7 +39,7 @@ void ParamGenerator::addParams(juce::AudioProcessor& p) {
   p.addParameter(gain = new juce::AudioParameterFloat(gainId, gainId, juce::NormalisableRange<float>(0.0f, 1.0f),
                                                       ParamDefaults::GAIN_DEFAULT));
   juce::String candidateId = PITCH_CLASS_NAMES[noteIdx] + ParamIDs::genCandidate + juce::String(genIdx);
-  p.addParameter(candidate = new juce::AudioParameterInt(candidateId, candidateId, 0, MAX_CANDIDATES - 1, genIdx));
+  p.addParameter(candidate = new juce::AudioParameterInt(candidateId, candidateId, 0, MAX_CANDIDATES - 1, 0));
   juce::String pitchAdjustId = PITCH_CLASS_NAMES[noteIdx] + ParamIDs::genPitchAdjust + juce::String(genIdx);
   p.addParameter(pitchAdjust = new juce::AudioParameterFloat(pitchAdjustId, pitchAdjustId, ParamRanges::PITCH_ADJUST, 0.0f));
   juce::String pitchSprayId = PITCH_CLASS_NAMES[noteIdx] + ParamIDs::genPitchSpray + juce::String(genIdx);
@@ -186,8 +186,17 @@ void ParamNote::removeListener(int genIdx, juce::AudioProcessorParameter::Listen
 }
 
 ParamCandidate* ParamNote::getCandidate(int genIdx) {
-  if (genIdx >= candidates.size()) return nullptr;
+  if (candidates.empty()) return nullptr;
   return &candidates[generators[genIdx]->candidate->get()];
+}
+
+void ParamNote::setStartingCandidatePosition() {
+  // We start each candidate position at zero and here update it to start each generator at a unique position.
+  // If there are only 2 candidate and 4 generators, we want genIdx 3 and 4 to also get candidate[1]
+  const int maxPosition = candidates.size() - 1;
+  for (int i = 0; i < NUM_GENERATORS; ++i) {
+    ParamHelper::setParam(generators[i].get()->candidate, (i > maxPosition) ? maxPosition : i);
+  }
 }
 
 bool ParamNote::shouldPlayGenerator(int genIdx) {
@@ -205,7 +214,7 @@ void ParamsNote::resetParams() {
     for (auto& generator : note->generators) {
       ParamHelper::setParam(generator->enable, generator->genIdx == 0);
       ParamHelper::setParam(generator->gain, ParamDefaults::GAIN_DEFAULT);
-      ParamHelper::setParam(generator->candidate, generator->genIdx);
+      ParamHelper::setParam(generator->candidate, 0);
       ParamHelper::setParam(generator->pitchAdjust, 0.0f);
       ParamHelper::setParam(generator->pitchSpray, 0.0f);
       ParamHelper::setParam(generator->positionAdjust, 0.0f);

--- a/Source/Parameters.h
+++ b/Source/Parameters.h
@@ -189,6 +189,7 @@ struct ParamNote {
   void removeListener(int genIdx, juce::AudioProcessorParameter::Listener* listener);
   bool shouldPlayGenerator(int genIdx);
   ParamCandidate* getCandidate(int genIdx);
+  void setStartingCandidatePosition();
 
   int noteIdx;
   std::vector<std::unique_ptr<ParamGenerator>> generators;

--- a/Source/PositionChanger.cpp
+++ b/Source/PositionChanger.cpp
@@ -64,12 +64,15 @@ void PositionChanger::paint(juce::Graphics& g) {
   g.drawRect(titleRect, 2);
 
   /* Draw position text */
+  juce::String posString;
   if (mPosition >= 0 && mNumPositions > 0) {
     int posNum = (mPosition >= 0) ? mPosition + 1 : 0;
-    juce::String posString = juce::String(posNum) + juce::String(" / ") + juce::String(mNumPositions);
-    g.setColour(bgColour);
-    g.drawText(posString, titleRect, juce::Justification::centred);
+    posString = juce::String(posNum) + juce::String(" / ") + juce::String(mNumPositions);
+  } else {
+    posString = "EMPTY";  // only can fit 5 letters in box, better then a blank boxs
   }
+  g.setColour(bgColour);
+  g.drawText(posString, titleRect, juce::Justification::centred);
 
   /* Solo button */
   mSoloRect = titleRect.translated(0, selectorHeight).withHeight(soloHeight - 2).toFloat();


### PR DESCRIPTION
After `createCandidates` set the starting position instead of just assuming there will be 4 candidates and using the generator index 