### PR TITLE
Add global setting and production build

### DIFF
--- a/Source/GeneratorsBox.cpp
+++ b/Source/GeneratorsBox.cpp
@@ -416,10 +416,7 @@ void GeneratorsBox::resized() {
   r.removeFromTop(TABS_HEIGHT);
 
   // Add insets
-  r.removeFromTop(PADDING_SIZE);
-  r.removeFromLeft(PADDING_SIZE);
-  r.removeFromRight(PADDING_SIZE);
-  r.removeFromBottom(PADDING_SIZE);
+  r.reduce(PADDING_SIZE, PADDING_SIZE);
 
   // Generator adjustments
   r.removeFromTop(SECTION_TITLE_HEIGHT);

--- a/Source/GranularSynth.cpp
+++ b/Source/GranularSynth.cpp
@@ -11,6 +11,7 @@
 #include "GranularSynth.h"
 
 #include "PluginEditor.h"
+#include "Settings.h"
 
 GranularSynth::GranularSynth()
 #ifndef JucePlugin_PreferredChannelConfigurations
@@ -313,7 +314,9 @@ juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter() {
     jassertfalse;
   }
 
-  return new GranularSynth();
+  GranularSynth* synth = new GranularSynth();
+  PowerUserSettings::get().setSynth(synth);
+  return synth;
 }
 
 void GranularSynth::handleGrainAddRemove(int blockSize) {
@@ -484,8 +487,8 @@ void GranularSynth::handleNoteOff(juce::MidiKeyboardState* state, int midiChanne
   }
 }
 
-void GranularSynth::resetParameters() {
-  mParamsNote.resetParams();
+void GranularSynth::resetParameters(bool fullClear) {
+  mParamsNote.resetParams(fullClear);
   mParamGlobal.resetParams();
 }
 

--- a/Source/GranularSynth.h
+++ b/Source/GranularSynth.h
@@ -87,7 +87,7 @@ class GranularSynth : public juce::AudioProcessor, juce::MidiKeyboardState::List
   const juce::Array<Utils::MidiNote>& getMidiNotes() { return mMidiNotes; }
 
   ParamUI& getParamUI() { return mParamUI; }
-  void resetParameters();
+  void resetParameters(bool fullClear = true);
   int incrementPosition(int genIdx, bool lookRight);
   std::vector<ParamCandidate*> getActiveCandidates();
 

--- a/Source/Parameters.cpp
+++ b/Source/Parameters.cpp
@@ -207,7 +207,7 @@ void ParamsNote::addParams(juce::AudioProcessor& p) {
   }
 }
 
-void ParamsNote::resetParams() {
+void ParamsNote::resetParams(bool fullClear) {
   for (auto& note : notes) {
     for (auto& generator : note->generators) {
       ParamHelper::setParam(generator->enable, generator->genIdx == 0);
@@ -230,7 +230,9 @@ void ParamsNote::resetParams() {
       ParamHelper::setParam(generator->filterResonance, ParamDefaults::FILTER_RESONANCE_DEFAULT);
       ParamHelper::setParam(generator->filterType, 0);
     }
-    note->candidates.clear();
+    if (fullClear) {
+      note->candidates.clear();
+    }
     ParamHelper::setParam(note->soloIdx, SOLO_NONE);
   }
 }

--- a/Source/Parameters.h
+++ b/Source/Parameters.h
@@ -256,7 +256,7 @@ struct ParamsNote {
   }
 
   void addParams(juce::AudioProcessor& p);
-  void resetParams();
+  void resetParams(bool fullClear = true);
 
   // always send creation and have callback scope decide if valid or not
   void grainCreated(Utils::PitchClass pitchClass, int genIdx, float durationSec, float envGain) {

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -107,7 +107,15 @@ GRainbowAudioProcessorEditor::GRainbowAudioProcessorEditor(GranularSynth& synth)
 
   startTimer(50);
 
-  setSize(1200, 650);
+  int editorWidth = 1200;
+  int editorHeight = 650;
+
+#ifndef GRAINBOW_PRODUCTION
+  addAndMakeVisible(mSettings);
+  editorHeight += mSettings.getHeight();
+#endif
+
+  setSize(editorWidth, editorHeight);
 }
 
 GRainbowAudioProcessorEditor::~GRainbowAudioProcessorEditor() {
@@ -176,6 +184,10 @@ void GRainbowAudioProcessorEditor::paint(juce::Graphics& g) {
   @brief Draw note display (the small section between the keyboard and arc spectrogram)
 */
 void GRainbowAudioProcessorEditor::paintOverChildren(juce::Graphics& g) {
+  if (!PowerUserSettings::get().getAnimated()) {
+    return;
+  }
+
   // Right now just give last note played, not truely polyphony yet
   const juce::Array<Utils::MidiNote>& midiNotes = mSynth.getMidiNotes();
   if (!midiNotes.isEmpty()) {
@@ -225,6 +237,10 @@ void GRainbowAudioProcessorEditor::paintOverChildren(juce::Graphics& g) {
 
 void GRainbowAudioProcessorEditor::resized() {
   auto r = getLocalBounds();
+
+#ifndef GRAINBOW_PRODUCTION
+  mSettings.setBounds(r.removeFromBottom(mSettings.getHeight()));
+#endif
 
   // Generators box
   auto leftPanel = r.removeFromLeft(PANEL_WIDTH);

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -20,10 +20,8 @@
 #include "RainbowLookAndFeel.h"
 #include "TransientDetector.h"
 #include "Utils.h"
+#include "Settings.h"
 
-//==============================================================================
-/**
- */
 class GRainbowAudioProcessorEditor : public juce::AudioProcessorEditor,
                                      juce::FileDragAndDropTarget,
                                      juce::Timer {
@@ -31,7 +29,6 @@ class GRainbowAudioProcessorEditor : public juce::AudioProcessorEditor,
   GRainbowAudioProcessorEditor(GranularSynth& synth);
   ~GRainbowAudioProcessorEditor() override;
 
-  //==============================================================================
   void paint(juce::Graphics&) override;
   void paintOverChildren(juce::Graphics& g) override;
   void resized() override;
@@ -76,6 +73,7 @@ class GRainbowAudioProcessorEditor : public juce::AudioProcessorEditor,
   GeneratorsBox mGeneratorsBox;
   juce::Rectangle<float> mNoteDisplayRect;
   juce::SharedResourcePointer<juce::TooltipWindow> mTooltipWindow;
+  SettingsComponent mSettings;
 
   // Synth owns, but need to grab params on reloading of plugin
   ParamUI& mParamUI;

--- a/Source/RainbowKeyboard.cpp
+++ b/Source/RainbowKeyboard.cpp
@@ -9,8 +9,7 @@
 */
 
 #include "RainbowKeyboard.h"
-
-#include <JuceHeader.h>
+#include "Settings.h"
 
 //==============================================================================
 RainbowKeyboard::RainbowKeyboard(juce::MidiKeyboardState& state) : mState(state) {
@@ -104,7 +103,7 @@ void RainbowKeyboard::drawKey(juce::Graphics& g, Utils::PitchClass pitchClass) {
   g.drawRect(area, isBlackKey(pitchClass) ? 2 : 1);
 
   // display animation to show the velocity level of the note
-  if (isDown) {
+  if (isDown && PowerUserSettings::get().getAnimated()) {
     AnimationLUT& lut = mAnimationLUT[pitchClass];
     juce::Rectangle<float> block = juce::Rectangle<float>(lut.noteWidthSplit, lut.noteWidthSplit);
     g.setColour(juce::Colours::white);

--- a/Source/Settings.cpp
+++ b/Source/Settings.cpp
@@ -1,0 +1,49 @@
+/*
+  ==============================================================================
+
+    Settings.cpp
+    Created: 8 Jun 2022 2:46:05pm
+    Author:  fricke
+
+  ==============================================================================
+*/
+
+#include "Settings.h"
+
+void PowerUserSettings::resetParameters() {
+  if (mSynth != nullptr) {
+    mSynth->resetParameters(false);
+  }
+}
+
+SettingsComponent::SettingsComponent() {
+  mBtnAnimation.setButtonText("Run animation");
+  mBtnAnimation.setColour(juce::TextButton::buttonColourId, juce::Colours::red);
+  mBtnAnimation.setColour(juce::TextButton::buttonOnColourId, juce::Colours::green);
+  mBtnAnimation.setToggleState(PowerUserSettings::get().getAnimated(), juce::NotificationType::dontSendNotification);
+  mBtnAnimation.setClickingTogglesState(true);
+  mBtnAnimation.onClick = [this] { PowerUserSettings::get().setAnimated(mBtnAnimation.getToggleState()); };
+  addAndMakeVisible(mBtnAnimation);
+
+  mBtnResetParameters.setButtonText("Reset Parameters");
+  mBtnResetParameters.setColour(juce::TextButton::buttonColourId, juce::Colours::red);
+  mBtnResetParameters.setColour(juce::TextButton::buttonOnColourId, juce::Colours::red);
+  mBtnResetParameters.onClick = [this] { PowerUserSettings::get().resetParameters(); };
+  addAndMakeVisible(mBtnResetParameters);
+}
+
+SettingsComponent::~SettingsComponent() {}
+
+void SettingsComponent::paint(juce::Graphics& g) {
+  g.drawLine(0.0f, 0.0f, static_cast<float>(getWidth()), 0.0f, static_cast<float>(mDivideLineSize));
+}
+
+void SettingsComponent::resized() {
+  auto r = getLocalBounds();
+  r.removeFromTop(mDivideLineSize);
+
+  const int buttonHeight = 30;
+  const int buttonWidth = 100;
+  mBtnAnimation.setBounds(r.removeFromTop(buttonHeight).withWidth(buttonWidth));
+  mBtnResetParameters.setBounds(r.removeFromTop(buttonHeight).withWidth(buttonWidth));
+}

--- a/Source/Settings.h
+++ b/Source/Settings.h
@@ -1,0 +1,64 @@
+/*
+  ==============================================================================
+
+    Settings.h
+    Created: 8 Jun 2022 2:46:05pm
+    Author:  fricke
+
+  ==============================================================================
+*/
+
+#pragma once
+
+#include <JuceHeader.h>
+
+#include "GranularSynth.h"
+
+/**
+    This class holds the state of the settings that are known globally at all times
+*/
+class PowerUserSettings {
+ public:
+  PowerUserSettings() : mIsAnimated(true), mSynth(nullptr){};
+  ~PowerUserSettings(){};
+
+  void setSynth(GranularSynth* synth) { mSynth = synth; }
+
+  void setAnimated(bool value) { mIsAnimated = value; }
+  bool getAnimated() { return mIsAnimated; }
+
+  void resetParameters();
+
+  // Creates a singleton
+  PowerUserSettings(PowerUserSettings const&) = delete;
+  void operator=(PowerUserSettings const&) = delete;
+  static PowerUserSettings& get() {
+    static PowerUserSettings instance;
+    return instance;
+  }
+
+ private:
+  bool mIsAnimated;
+
+  GranularSynth* mSynth;
+};
+
+/**
+    This class is the component part of the settings, it lets you edit the settings but destroyed when the editor closes
+*/
+class SettingsComponent : public juce::Component {
+ public:
+  SettingsComponent();
+  ~SettingsComponent() override;
+
+  void paint(juce::Graphics& g) override;
+  void resized() override;
+
+  // height of setting component
+  int getHeight() { return 100; }
+
+private:
+  const int mDivideLineSize = 5;
+  juce::TextButton mBtnAnimation;
+  juce::TextButton mBtnResetParameters;
+};

--- a/gRainbow.jucer
+++ b/gRainbow.jucer
@@ -7,6 +7,8 @@
   <MAINGROUP id="SNaS8k" name="gRainbow">
     <GROUP id="{595D4325-C686-1839-D048-A225A7FE150A}" name="Source">
       <GROUP id="{5E1AB70E-1865-A28B-6DCD-3168747A76FD}" name="Components">
+        <FILE id="wfqhFs" name="Settings.cpp" compile="1" resource="0" file="Source/Settings.cpp"/>
+        <FILE id="nrOvLX" name="Settings.h" compile="0" resource="0" file="Source/Settings.h"/>
         <FILE id="GqrDVH" name="NoteGrid.cpp" compile="1" resource="0" file="Source/NoteGrid.cpp"/>
         <FILE id="gsT0kQ" name="NoteGrid.h" compile="0" resource="0" file="Source/NoteGrid.h"/>
         <FILE id="BHxSYv" name="FilterControl.cpp" compile="1" resource="0"
@@ -88,6 +90,8 @@
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug" targetName="gRainbow" defines="JUCE_MODAL_LOOPS_PERMITTED=1,CFLAGS='-Wunused-variable'"/>
         <CONFIGURATION isDebug="0" name="Release" targetName="gRainbow" defines="JUCE_MODAL_LOOPS_PERMITTED=1,CFLAGS='-Wunused-variable'"/>
+        <CONFIGURATION isDebug="0" name="Production" targetName="gRainbow" defines="GRAINBOW_PRODUCTION=1,JUCE_MODAL_LOOPS_PERMITTED=1,CFLAGS='-Wunused-variable'"
+                       userNotes="Same as release with developer configurations removed"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_audio_basics" path="../../../../../../JUCE/modules"/>
@@ -130,6 +134,8 @@
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug" targetName="gRainbow" defines="JUCE_MODAL_LOOPS_PERMITTED=1"/>
         <CONFIGURATION isDebug="0" name="Release" targetName="gRainbow" defines="JUCE_MODAL_LOOPS_PERMITTED=1"/>
+        <CONFIGURATION isDebug="0" name="Production" targetName="gRainbow" defines="GRAINBOW_PRODUCTION=1,JUCE_MODAL_LOOPS_PERMITTED=1"
+                       userNotes="Same as release with developer configurations removed"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_audio_basics" path="../../../../../../JUCE/modules"/>
@@ -151,6 +157,8 @@
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug" targetName="gRainbow" defines="JUCE_MODAL_LOOPS_PERMITTED=1"/>
         <CONFIGURATION isDebug="0" name="Release" targetName="gRainbow" defines="JUCE_MODAL_LOOPS_PERMITTED=1"/>
+        <CONFIGURATION isDebug="0" name="Production" targetName="gRainbow" defines="GRAINBOW_PRODUCTION=1,JUCE_MODAL_LOOPS_PERMITTED=1"
+                       userNotes="Same as release with developer configurations removed"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_audio_basics" path="../../../../../../JUCE/modules"/>


### PR DESCRIPTION
Adds a global setting section at the bottom of the plugin. Also added a new `Production` build option in Projucer that is just `Release` but with `GRAINBOW_PRODUCTION` set.

