### PR TITLE
Fix JUCE 7 deprecation warnings

### DIFF
--- a/Source/GranularSynth.cpp
+++ b/Source/GranularSynth.cpp
@@ -331,13 +331,18 @@ void GranularSynth::handleGrainAddRemove(int blockSize) {
           if (paramGenerator->grainSync->get()) {
             float div = std::pow(2, (int)(ParamRanges::SYNC_DIV_MAX *
                                           paramGenerator->grainDuration->convertTo0to1(paramGenerator->grainDuration->get())));
-            float bpm = DEFAULT_BPM;
+            double bpm = DEFAULT_BPM;
             int beatsPerBar = 4;
-            if (auto* playhead = getPlayHead()) {
-              juce::AudioPlayHead::CurrentPositionInfo info;
-              playhead->getCurrentPosition(info);
-              bpm = info.bpm;
-              beatsPerBar = info.timeSigNumerator;
+            if (juce::AudioPlayHead* playhead = getPlayHead()) {
+              juce::Optional<juce::AudioPlayHead::PositionInfo> info = playhead->getPosition();
+              juce::Optional<double> newBpm = info->getBpm();
+              if (newBpm) {
+                bpm = *newBpm;
+              }
+              juce::Optional<juce::AudioPlayHead::TimeSignature> newTimeSignature = info->getTimeSignature();
+              if (newTimeSignature) {
+                beatsPerBar = (*newTimeSignature).numerator;
+              }
             }
             // Find synced duration using bpm
             durSec = (1.0f / bpm) * 60.0f * (beatsPerBar / div);

--- a/Source/GranularSynth.h
+++ b/Source/GranularSynth.h
@@ -97,7 +97,7 @@ class GranularSynth : public juce::AudioProcessor, juce::MidiKeyboardState::List
   // DSP constants
   static constexpr auto FFT_SIZE = 4096;
   static constexpr auto HOP_SIZE = 2048;
-  static constexpr auto DEFAULT_BPM = 120;
+  static constexpr double DEFAULT_BPM = 120.0f;
   // Param bounds
   static constexpr auto MIN_RATE_RATIO = .25f;
   static constexpr auto MAX_RATE_RATIO = 1.0f;


### PR DESCRIPTION
`getCurrentPosition` is deprecated for `getPosition` as some DAW don't return a value properly, hence the `juce::Optional` which is just JUCE's version of `std::optional`