### PR TITLE
enable mp3 support

### DIFF
--- a/gRainbow.jucer
+++ b/gRainbow.jucer
@@ -87,7 +87,8 @@
       <FILE id="VcqOMO" name="Utils.h" compile="0" resource="0" file="Source/Utils.h"/>
     </GROUP>
   </MAINGROUP>
-  <JUCEOPTIONS JUCE_STRICT_REFCOUNTEDPOINTER="1" JUCE_VST3_CAN_REPLACE_VST2="0"/>
+  <JUCEOPTIONS JUCE_STRICT_REFCOUNTEDPOINTER="1" JUCE_VST3_CAN_REPLACE_VST2="0"
+               JUCE_USE_MP3AUDIOFORMAT="1"/>
   <EXPORTFORMATS>
     <LINUX_MAKE targetFolder="Builds/LinuxMakefile">
       <CONFIGURATIONS>


### PR DESCRIPTION
https://github.com/juce-framework/JUCE/blob/master/modules/juce_audio_formats/juce_audio_formats.h#L78-L92

> /** Config: JUCE_USE_MP3AUDIOFORMAT
    Enables the software-based MP3AudioFormat class.
    IMPORTANT DISCLAIMER: By choosing to enable the JUCE_USE_MP3AUDIOFORMAT flag and to compile
    this MP3 code into your software, you do so AT YOUR OWN RISK! By doing so, you are agreeing
    that Raw Material Software Limited is in no way responsible for any patent, copyright, or other
    legal issues that you may suffer as a result.
    The code in juce_MP3AudioFormat.cpp is NOT guaranteed to be free from infringements of 3rd-party
    intellectual property. If you wish to use it, please seek your own independent advice about the
    legality of doing so. If you are not willing to accept full responsibility for the consequences
    of using this code, then do not enable this setting.
*/

So my knowledge about MP3 legality is the second we make any money then we might want to consider removing this

If we don't want to support MP3, then we need to update

```
    juce::FileChooser chooser("Select a file to granulize...", juce::File::getCurrentWorkingDirectory(), "*.wav;*.mp3;*.gbow",
                              true);
 ```